### PR TITLE
Fix workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+  actions: read
+  packages: read
+  id-token: write
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/david-uhlig/tendril-tasks/security/code-scanning/1](https://github.com/david-uhlig/tendril-tasks/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for all jobs. Based on the workflow's actions, the following permissions are necessary:
- `contents: read` for checking out the repository code.
- `actions: read` for interacting with GitHub Actions metadata.
- `packages: read` for dependency management (if applicable).
- `write` permissions for `actions/upload-artifact` to upload test artifacts.

We will add the `permissions` block at the top level of the workflow file to apply these permissions to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
